### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ SwiftHelpers is focused on making simpler the most tedious and repeating tasks w
 ## Requirements
 
 - iOS 8.0+
-- XCode 7.2+
+- Xcode 7.2+
 
 ## Installation guide
 > Dynamic libraries or those made with Swift, require iOS 8.0+


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
